### PR TITLE
Update spark pipeline instructions.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -145,6 +145,7 @@ rst_epilog = """
 .. ### Google Guide Links
 .. _Google Developers Console Guide: https://developers.google.com/console/help/new/
 .. _Google Identity Platform Guide: https://developers.google.com/identity/protocols/OAuth2
+.. _Application Default Credentials: https://developers.google.com/identity/protocols/application-default-credentials
 
 .. ### Google Product Links
 .. _Google BigQuery: https://cloud.google.com/bigquery/
@@ -153,7 +154,8 @@ rst_epilog = """
 .. _Google Compute Engine: https://cloud.google.com/compute/
 .. _Google Developers Console: https://console.developers.google.com/
 .. _Google Genomics: https://cloud.google.com/genomics/
-.. _Google Cloud Datalab: https://cloud.google.com/datalab/.
+.. _Google Cloud Datalab: https://cloud.google.com/datalab/
+.. _Google Cloud Dataproc: https://cloud.google.com/dataproc/
 
 .. ### Deep links into the Developers Console
 .. _Project List: https://console.developers.google.com/project
@@ -194,6 +196,7 @@ rst_epilog = """
 .. _NCBI BLAST Cloud Documentation: http://ncbi.github.io/blast-cloud/
 .. _S3IT: http://www.s3it.uzh.ch/
 .. _SLURM: https://computing.llnl.gov/linux/slurm/
+.. _ALPN: http://www.eclipse.org/jetty/documentation/9.2.10.v20150310/alpn-chapter.html
 
 .. _Bioconductor: http://www.bioconductor.org/
 .. _Using Bioconductor: http://www.bioconductor.org/install/

--- a/docs/source/includes/spark_setup.rst
+++ b/docs/source/includes/spark_setup.rst
@@ -1,41 +1,48 @@
-(1) Use `bdutil <https://cloud.google.com/hadoop/bdutil>`_ **version 1.2.1** or higher to deploy the cluster.  If you have not already done so, `install and configure <https://cloud.google.com/hadoop/>`_ bdutil.
+* Deploy your Spark cluster using `Google Cloud Dataproc`_.
 
-.. code-block:: shell
+  .. code-block:: shell
 
-  ./bdutil -e extensions/spark/spark_env.sh deploy
+    gcloud beta dataproc clusters create example-cluster --scopes cloud-platform
 
-(2) Copy your ``client_secrets.json`` to the master.  If you do not already have this file, see the `sign up instructions <https://cloud.google.com/genomics/install-genomics-tools#authenticate>`_ to obtain it.
+* ssh to the master.
 
-.. code-block:: shell
+  .. code-block:: shell
 
-  gcloud compute copy-files client_secrets.json hadoop-m:~/
+    gcloud compute ssh example-cluster-m
 
-(3) ssh to the master.
+* Compile and build the pipeline jar.  You can `build locally <https://github.com/googlegenomics/spark-examples>`_ or build on the Spark master running on Google Compute Engine.
 
-.. code-block:: shell
+.. container:: toggle
 
-  gcloud compute ssh hadoop-m
+  .. container:: header
 
-(4) Install `sbt <http://www.scala-sbt.org/release/tutorial/Installing-sbt-on-Linux.html>`_.
+    To compile and build on Compute Engine: **Show/Hide Instructions**
 
-.. code-block:: shell
+  .. container:: content
 
-  echo "deb http://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
-  sudo apt-get update
-  sudo apt-get install sbt
+    (1) Install `sbt <http://www.scala-sbt.org/release/tutorial/Installing-sbt-on-Linux.html>`_.
 
-(5) Clone the github repository.
+      .. code-block:: shell
 
-.. code-block:: shell
+        echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
+        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 642AC823
+        sudo apt-get install apt-transport-https
+        sudo apt-get update
+        sudo apt-get install sbt
 
-  sudo apt-get install git
-  git clone https://github.com/googlegenomics/spark-examples.git
+    (2) Clone the github repository.
 
-(6) Compile the Jar.
+      .. code-block:: shell
 
-.. code-block:: shell
+        sudo apt-get install git
+        git clone https://github.com/googlegenomics/spark-examples.git
 
-  cd spark-examples
-  sbt assembly
-  cp target/scala-2.10/googlegenomics-spark-examples-assembly-*.jar ~/
-  cd ~/
+    (3) Compile the Jar.
+
+      .. code-block:: shell
+
+        cd spark-examples
+        sbt assembly
+        cp target/scala-2.10/googlegenomics-spark-examples-assembly-*.jar ~/
+        cd ~/
+

--- a/docs/source/use_cases/compute_principal_coordinate_analysis/1-way-pca.rst
+++ b/docs/source/use_cases/compute_principal_coordinate_analysis/1-way-pca.rst
@@ -74,7 +74,7 @@ Spark
 Setup
 ^^^^^
 
-.. include:: /includes/collapsible_spark_setup_instructions.rst
+.. include:: /includes/spark_setup.rst
 
 Run the job
 ^^^^^^^^^^^
@@ -86,20 +86,23 @@ The following command will run PCA over the BRCA1 region within the :doc:`/use_c
   spark-submit \
     --class com.google.cloud.genomics.spark.examples.VariantsPcaDriver \
     --conf spark.shuffle.spill=true \
-    --master spark://hadoop-m:7077 \
-    /PATH/TO/googlegenomics-spark-examples-assembly-1.0.jar \
-    --client-secrets /PATH/TO/YOUR/client_secrets.json \
+    googlegenomics-spark-examples-assembly-1.0.jar \
     --variant-set-id 3049512673186936334 \
     --references chr17:41196311:41277499 \
     --output-path gs://YOUR-BUCKET/output/platinum-genomes-brca1-pca.tsv
 
-The above command line runs the job over a small portion of the genome, only taking a few minutes.  If modified to run over a larger portion of the genome or the entire genome, it may take a few hours depending upon how many machines are in the Spark cluster.
+The above command line runs the job over a small portion of the genome, only taking a couple minutes.  If modified to run over a larger portion of the genome or the entire genome, it may take a few hours depending upon how many machines are in the Spark cluster.
 
 To run this job over the entire genome:
 
+* Create a larger cluster: ``gcloud beta dataproc clusters create cluster-2 --scopes cloud-platform --num-workers #``
 * Add ``--num-reduce-partitions #`` to be equal to the number of cores in your cluster.
 * Use ``--all-references`` instead of ``--references chr17:41196311:41277499`` to run over the entire genome.
-* To run the job on a different dataset, change the variant set id for the ``--variant-set-id`` id parameter.
+
+To run the job on a different dataset:
+
+* Change the variant set id for the ``--variant-set-id`` id parameter.
+* If the `Application Default Credentials`_ are not sufficient, use ``--client-secrets PATH/TO/YOUR/client_secrets.json``.  If you do not already have this file, see the `sign up instructions <https://cloud.google.com/genomics/install-genomics-tools#authenticate>`_ to obtain it.
 
 Additional details
 ^^^^^^^^^^^^^^^^^^

--- a/docs/source/use_cases/compute_principal_coordinate_analysis/2-way-pca.rst
+++ b/docs/source/use_cases/compute_principal_coordinate_analysis/2-way-pca.rst
@@ -34,7 +34,7 @@ An `Apache Spark`_ implementation is available.
 Setup
 -----
 
-.. include:: /includes/collapsible_spark_setup_instructions.rst
+.. include:: /includes/spark_setup.rst
 
 Run the job
 -----------
@@ -46,20 +46,23 @@ The following command will run a two-way PCA over the BRCA1 region within the :d
   spark-submit \
     --class com.google.cloud.genomics.spark.examples.VariantsPcaDriver \
     --conf spark.shuffle.spill=true \
-    --master spark://hadoop-m:7077 \
-    /PATH/TO/googlegenomics-spark-examples-assembly-1.0.jar \
-    --client-secrets /PATH/TO/YOUR/client_secrets.json \
+    googlegenomics-spark-examples-assembly-1.0.jar \
     --variant-set-id 10473108253681171589 3049512673186936334 \
     --references 17:41196311:41277499 chr17:41196311:41277499 \
     --output-path gs://YOUR-BUCKET/output/two-way-brca1-pca.tsv
 
-The above command line runs the job over a small portion of the genome, only taking a few minutes.  If modified to run over a larger portion of the genome or the entire genome, it may take a few hours depending upon how many machines are in the Spark cluster.
+The above command line runs the job over a small portion of the genome, only taking a couple minutes.  If modified to run over a larger portion of the genome or the entire genome, it may take a few hours depending upon how many machines are in the Spark cluster.
 
 To run this job over the entire genome:
 
+* Create a larger cluster: ``gcloud beta dataproc clusters create cluster-2 --scopes cloud-platform --num-workers #``
 * Add ``--num-reduce-partitions #`` to be somewhere between 10-20 this will be the level of parallelism when computing the reference call similarity, keep it bounded to a small number, otherwise the shuffle will need to move a full similarity matrix for each reducer.
-* Use ``--all-references`` instead of ``--references  17:41196311:41277499 chr17:41196311:41277499`` to run over the entire genome.
-* To run the job on a different dataset, change the second variant set id for the ``--variant-set-id`` id parameter and update the second value in ``--references`` as appropriate.
+* Use ``--all-references`` instead of ``--references 17:41196311:41277499 chr17:41196311:41277499`` to run over the entire genome.
+
+To run the job on a different dataset:
+
+* Change the second variant set id for the ``--variant-set-id`` id parameter and update the second value in ``--references`` as appropriate.
+* If the `Application Default Credentials`_ are not sufficient, use ``--client-secrets PATH/TO/YOUR/client_secrets.json``.  If you do not already have this file, see the `sign up instructions <https://cloud.google.com/genomics/install-genomics-tools#authenticate>`_ to obtain it.
 
 Additional details
 ------------------


### PR DESCRIPTION
Fixes https://github.com/googlegenomics/readthedocs/issues/42 by directing users to Dataproc.